### PR TITLE
use of `tf.slice` to crop images

### DIFF
--- a/tf2/data_util.py
+++ b/tf2/data_util.py
@@ -290,10 +290,7 @@ def distorted_bounding_box_crop(image,
     bbox_begin, bbox_size, _ = sample_distorted_bounding_box
 
     # Crop the image to the specified bounding box.
-    offset_y, offset_x, _ = tf.unstack(bbox_begin)
-    target_height, target_width, _ = tf.unstack(bbox_size)
-    image = tf.image.crop_to_bounding_box(
-        image, offset_y, offset_x, target_height, target_width)
+    image = tf.slice(image, bbox_begin, bbox_begin)
 
     return image
 


### PR DESCRIPTION
In this PR I have tried using the `tf.slice` method to crop images paired with the `tf.image.sample_distorted_bounding_box` method.

The inspiration of this comes from the official docs of [tf.image.sample_distorted_bounding_box](https://www.tensorflow.org/api_docs/python/tf/image/sample_distorted_bounding_box).